### PR TITLE
Use Sneaking Suit's own durability stat

### DIFF
--- a/zscript/undeadzeratul/elements/UZArmour.zs
+++ b/zscript/undeadzeratul/elements/UZArmour.zs
@@ -374,7 +374,7 @@ class UZArmour : HUDElement {
 			stats.wornlayer = STRIP_ARMOUR;
 			stats.fg = "SNKSA0";
 			stats.bg = "SNKSB0";
-			stats.durability = 144; // HDDamageHandler doesn't have current durability...
+			stats.durability = arm.durability;
 			stats.maxDurability = 144; // HDCONST_SNEAKINGSUIT
 			stats.fontColor = Font.CR_DARKGRAY;
 			stats.offX = hasHelmet ? _body_hlm_posX.GetInt() : _body_nhm_posX.GetInt();


### PR DESCRIPTION
This will require the latest build of the Sneaking Suit (anything after [this commit](https://codeberg.org/Wanzer/HDst_WAN_SneakingSuit/commit/49247e4d7bdedf0c5672b2f02ef756d0cd3c365e)), but will allow the HUD Element to use the actual durability instead of a hardcode value