### PR TITLE
Add Safety Check to getting font for HUD Elements

### DIFF
--- a/zscript/undeadzeratul/base/BaseCounter.zs
+++ b/zscript/undeadzeratul/base/BaseCounter.zs
@@ -87,7 +87,8 @@ class BaseCounterHUDElement : HUDElement abstract {
 
         string newFont = _font.GetString();
         if (_prevFont != newFont) {
-            _hudFont = HUDFont.create(Font.FindFont(newFont));
+            let font = Font.FindFont(newFont);
+            _hudFont = HUDFont.create(font ? font : Font.FindFont('NewSmallFont'));
             _prevFont = newFont;
         }
     }

--- a/zscript/undeadzeratul/elements/UZAmmoCounters.zs
+++ b/zscript/undeadzeratul/elements/UZAmmoCounters.zs
@@ -72,7 +72,8 @@ class UZAmmoCounters : HUDAmmoCounters {
 
         string newFont = _font.GetString();
         if (_prevFont != newFont) {
-            _hudFont = HUDFont.create(Font.FindFont(newFont));
+            let font = Font.FindFont(newFont);
+            _hudFont = HUDFont.create(font ? font : Font.FindFont('NewSmallFont'));
             _prevFont = newFont;
         }
     }

--- a/zscript/undeadzeratul/elements/UZArmour.zs
+++ b/zscript/undeadzeratul/elements/UZArmour.zs
@@ -155,7 +155,8 @@ class UZArmour : HUDElement {
 
         string newFont = _font.GetString();
         if (_prevFont != newFont) {
-            _hudFont = HUDFont.create(Font.FindFont(newFont));
+            let font = Font.FindFont(newFont);
+            _hudFont = HUDFont.create(font ? font : Font.FindFont('NewSmallFont'));
             _prevFont = newFont;
         }
     }

--- a/zscript/undeadzeratul/elements/UZCompass.zs
+++ b/zscript/undeadzeratul/elements/UZCompass.zs
@@ -57,7 +57,8 @@ class UZCompass : HUDCompass {
 
         string newFont = _font.GetString();
         if (_prevFont != newFont) {
-            _hudFont = HUDFont.create(Font.FindFont(newFont));
+            let font = Font.FindFont(newFont);
+            _hudFont = HUDFont.create(font ? font : Font.FindFont('NewSmallFont'));
             _prevFont = newFont;
         }
     }

--- a/zscript/undeadzeratul/elements/UZEKG.zs
+++ b/zscript/undeadzeratul/elements/UZEKG.zs
@@ -68,7 +68,8 @@ class UZEKG : HUDEKG {
 
         string newFont = _font.GetString();
         if (_prevFont != newFont) {
-            _hudFont = HUDFont.create(Font.FindFont(newFont));
+            let font = Font.FindFont(newFont);
+            _hudFont = HUDFont.create(font ? font : Font.FindFont('NewSmallFont'));
             _prevFont = newFont;
         }
     }

--- a/zscript/undeadzeratul/elements/UZEncumbrance.zs
+++ b/zscript/undeadzeratul/elements/UZEncumbrance.zs
@@ -57,7 +57,8 @@ class UZEncumbrance : HUDEncumbrance {
 
         string newFont = _font.GetString();
         if (_prevFont != newFont) {
-            _hudFont = HUDFont.create(Font.FindFont(newFont));
+            let font = Font.FindFont(newFont);
+            _hudFont = HUDFont.create(font ? font : Font.FindFont('NewSmallFont'));
             _prevFont = newFont;
         }
     }

--- a/zscript/undeadzeratul/elements/UZInventory.zs
+++ b/zscript/undeadzeratul/elements/UZInventory.zs
@@ -57,7 +57,8 @@ class UZInventory : HUDInventory {
 
         string newFont = _font.GetString();
         if (_prevFont != newFont) {
-            _hudFont = HUDFont.create(Font.FindFont(newFont));
+            let font = Font.FindFont(newFont);
+            _hudFont = HUDFont.create(font ? font : Font.FindFont('NewSmallFont'));
             _prevFont = newFont;
         }
     }

--- a/zscript/undeadzeratul/elements/UZObjectDescription.zs
+++ b/zscript/undeadzeratul/elements/UZObjectDescription.zs
@@ -64,7 +64,8 @@ class UZObjectDescription : HUDElement {
 
         string newFont = _font.GetString();
         if (_prevFont != newFont) {
-            _hudFont = HUDFont.create(Font.FindFont(newFont));
+            let font = Font.FindFont(newFont);
+            _hudFont = HUDFont.create(font ? font : Font.FindFont('NewSmallFont'));
             _prevFont = newFont;
         }
     }

--- a/zscript/undeadzeratul/elements/UZPosition.zs
+++ b/zscript/undeadzeratul/elements/UZPosition.zs
@@ -57,7 +57,8 @@ class UZPosition : HUDPosition {
 
         string newFont = _font.GetString();
         if (_prevFont != newFont) {
-            _hudFont = HUDFont.create(Font.FindFont(newFont));
+            let font = Font.FindFont(newFont);
+            _hudFont = HUDFont.create(font ? font : Font.FindFont('NewSmallFont'));
             _prevFont = newFont;
         }
     }

--- a/zscript/undeadzeratul/elements/UZSquadStatus.zs
+++ b/zscript/undeadzeratul/elements/UZSquadStatus.zs
@@ -156,7 +156,8 @@ class UZSquadStatus : HUDElement {
 
         string newFont = _font.GetString();
         if (_prevFont != newFont) {
-            _hudFont = HUDFont.create(Font.FindFont(newFont));
+            let font = Font.FindFont(newFont);
+            _hudFont = HUDFont.create(font ? font : Font.FindFont('NewSmallFont'));
             _prevFont = newFont;
         }
     }

--- a/zscript/undeadzeratul/elements/UZWeaponHelp.zs
+++ b/zscript/undeadzeratul/elements/UZWeaponHelp.zs
@@ -62,7 +62,8 @@ class UZWeaponHelp : HUDElement {
 
         string newFont = _font.GetString();
         if (_prevFont != newFont) {
-            _hudFont = HUDFont.create(Font.FindFont(newFont));
+            let font = Font.FindFont(newFont);
+            _hudFont = HUDFont.create(font ? font : Font.FindFont('NewSmallFont'));
             _prevFont = newFont;
         }
     }

--- a/zscript/undeadzeratul/elements/UZWeaponStash.zs
+++ b/zscript/undeadzeratul/elements/UZWeaponStash.zs
@@ -72,7 +72,8 @@ class UZWeaponStash : HUDWeaponStash {
 
         string newFont = _font.GetString();
         if (_prevFont != newFont) {
-            _hudFont = HUDFont.create(Font.FindFont(newFont));
+            let font = Font.FindFont(newFont);
+            _hudFont = HUDFont.create(font ? font : Font.FindFont('NewSmallFont'));
             _prevFont = newFont;
         }
     }

--- a/zscript/undeadzeratul/elements/UZWoundCounter.zs
+++ b/zscript/undeadzeratul/elements/UZWoundCounter.zs
@@ -76,7 +76,8 @@ class UZWoundCounter : HUDElement {
 
         string newFont = _font.GetString();
         if (_prevFont != newFont) {
-            _hudFont = HUDFont.create(Font.FindFont(newFont));
+            let font = Font.FindFont(newFont);
+            _hudFont = HUDFont.create(font ? font : Font.FindFont('NewSmallFont'));
             _prevFont = newFont;
         }
 


### PR DESCRIPTION
If the font doesn't exist, just fallback to NewSmallFont, as that's HDest's default font anyways.